### PR TITLE
로그인, 회원가입 페이지

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import {
+  ChakraProvider,
+  Flex,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Button,
+  Heading,
+} from '@chakra-ui/react';
+
+const LoginPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    // 여기에 로그인 로직을 추가할 수 있습니다.
+    console.log('Email:', email);
+    console.log('Password:', password);
+  };
+
+  return (
+    <ChakraProvider>
+      <Flex minHeight="100vh" alignItems="center" justifyContent="center">
+        <Box
+          borderWidth={1}
+          px={4}
+          py={8}
+          maxWidth="400px"
+          width="100%"
+          boxShadow="md"
+          rounded="md"
+        >
+          <Heading textAlign="center" mb={6}>
+            로그인
+          </Heading>
+          <FormControl>
+            <FormLabel>Email 주소</FormLabel>
+            <Input
+              type="email"
+              placeholder="이메일을 입력하세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              mb={4}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>비밀번호</FormLabel>
+            <Input
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              mb={4}
+            />
+          </FormControl>
+          <Button colorScheme="blue" onClick={handleLogin} width="100%">
+            로그인
+          </Button>
+        </Box>
+      </Flex>
+    </ChakraProvider>
+  );
+};
+
+export default LoginPage;

--- a/pages/login_select.js
+++ b/pages/login_select.js
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  Heading,
+  Text,
+  Link,
+} from "@chakra-ui/react";
+
+const LoginForm = () => {
+  return (
+    <Box
+      w="400px"
+      p={8}
+      borderWidth={1}
+      borderRadius={8}
+      boxShadow="lg"
+      bg="white"
+    >
+      <Heading mb={4} textAlign="center">
+        Welcome back!
+      </Heading>
+      <Text mb={8} textAlign="center" color="gray.500">
+        Log in to your account to continue.
+      </Text>
+      <Stack spacing={4}>
+        <FormControl id="email">
+          <FormLabel>Email Address</FormLabel>
+          <Input type="email" placeholder="Enter your email" />
+        </FormControl>
+        <FormControl id="password">
+          <FormLabel>Password</FormLabel>
+          <Input type="password" placeholder="Enter your password" />
+        </FormControl>
+        <Link href='./login'>
+        <Button colorScheme="blue" width="full">
+          Log In
+        </Button>
+        </Link>
+        
+      </Stack>
+      <Text mt={4} textAlign="center">
+        Don't have an account?{" "}
+        <Link color="blue.500" href="./signup">
+          Sign Up
+        </Link>
+      </Text>
+    </Box>
+  );
+};
+
+export default LoginForm;

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import {
+  ChakraProvider,
+  Flex,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Button,
+  Heading,
+} from '@chakra-ui/react';
+
+const SignUpPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignUp = () => {
+    // 여기에 회원가입 로직을 추가할 수 있습니다.
+    console.log('Email:', email);
+    console.log('Password:', password);
+  };
+
+  return (
+    <ChakraProvider>
+      <Flex minHeight="100vh" alignItems="center" justifyContent="center">
+        <Box
+          borderWidth={1}
+          px={4}
+          py={8}
+          maxWidth="400px"
+          width="100%"
+          boxShadow="md"
+          rounded="md"
+        >
+          <Heading textAlign="center" mb={6}>
+            회원가입
+          </Heading>
+          <FormControl>
+            <FormLabel>Email 주소</FormLabel>
+            <Input
+              type="email"
+              placeholder="이메일을 입력하세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              mb={4}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>비밀번호</FormLabel>
+            <Input
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              mb={4}
+            />
+          </FormControl>
+          <Button colorScheme="blue" onClick={handleSignUp} width="100%">
+            가입하기
+          </Button>
+        </Box>
+      </Flex>
+    </ChakraProvider>
+  );
+};
+
+export default SignUpPage;


### PR DESCRIPTION
로그인, 회원가입에 필요한 페이지들만 만들어 두었습니다! 

페이지에 필요한 부분은 상의를 통해 수정해나가고, 디자인도 천천히 변경하면 될 것 같습니다. 

1. login_select.js (로그인, 회원가입 선택창)
: chatGPT에서 로그인 하기 이전, 로그인 또는 회원가입을 선택하는 창을 보고 비슷하게 만들 명목으로 페이지를 할당했습니다. 

2. login.js (로그인 페이지)
: 기본적인 로그인 틀을 갖춘 페이지입니다.

3. signup.js (회원가입 페이지)
: 기본적인 회원가입 틀을 갖춰 놓은 페이지입니다. 

테스트할 때 해당 페이지들만 확인하려고 한다면, 
npm run dev를 통해 실행시킨 이후 
http://localhost:3000/(파일명) 을 작성해주시면 됩니다!